### PR TITLE
Implementar Cache usando Redis

### DIFF
--- a/StockApp.API/Program.cs
+++ b/StockApp.API/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.OpenApi.Models;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
 
 internal class Program
 {
@@ -25,6 +26,11 @@ internal class Program
 
         builder.Services.AddSingleton<ICompetitivenessAnalysisService, CompetitivenessAnalysisService>();
         builder.Services.AddScoped<IProductRepository, ProductRepository>();
+
+        builder.Services.AddStackExchangeRedisCache(Options =>
+        {
+            Options.Configuration = builder.Configuration.GetConnectionString("Redis");
+        });
 
 
         var key = Encoding.ASCII.GetBytes(builder.Configuration["Jwt:Key"]);

--- a/StockApp.API/StockApp.API.csproj
+++ b/StockApp.API/StockApp.API.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="BCrypt.Net" Version="0.1.0" />
     <PackageReference Include="JWT" Version="10.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.31" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.6" />
     <PackageReference Include="MySql.Data" Version="8.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>

--- a/StockApp.API/appsettings.json
+++ b/StockApp.API/appsettings.json
@@ -2,6 +2,9 @@
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=sqlicomalab.database.windows.net;Initial Catalog=stockapp_db_icoma;User ID=victoricoma;Password=Gordinho123;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False"
   },
+  "ConnectionStrings": {
+    "Redis": "sua_string_de_conexao_redis_aqui"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
- [ ] Configuração do Serviço de Cache Redis: Utilizei o método AddStackExchangeRedisCache para configurar o serviço de cache Redis na minha aplicação ASP.NET Core.
- [ ] A configuração foi realizada dentro do método ConfigureServices do arquivo Startup.cs ou equivalente.
- [ ] Configuração da Conexão Redis: Defini a configuração do Redis através da propriedade Options.Configuration, utilizando o método GetConnectionString do builder.Configuration.
- [ ] O método GetConnectionString obteve a string de conexão nomeada "Redis" do arquivo de configuração da aplicação (geralmente appsettings.json ou variáveis de ambiente).