### PR TITLE
Adicionar Logging usando Serilog

### DIFF
--- a/StockApp.API/Program.cs
+++ b/StockApp.API/Program.cs
@@ -12,6 +12,8 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.OpenApi.Models;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Serilog;
+using Serilog.Events;
 
 internal class Program
 {
@@ -31,6 +33,18 @@ internal class Program
         {
             Options.Configuration = builder.Configuration.GetConnectionString("Redis");
         });
+
+        Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .WriteTo.File("logs\\log.txt", rollingInterval: RollingInterval.Day)
+    .CreateLogger();
+
+        builder.Host.UseSerilog();
+
+
 
 
         var key = Encoding.ASCII.GetBytes(builder.Configuration["Jwt:Key"]);

--- a/StockApp.API/StockApp.API.csproj
+++ b/StockApp.API/StockApp.API.csproj
@@ -12,6 +12,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.31" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.6" />
     <PackageReference Include="MySql.Data" Version="8.4.0" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 


### PR DESCRIPTION
- [ ] Configuração Inicial do Logger (Log.Logger): MinimumLevel.Debug(): Define o nível mínimo de log como Debug.
- [ ] MinimumLevel.Override("Microsoft", LogEventLevel.Information): Sobrescreve o nível de log para qualquer log vindo de componentes da Microsoft para Information.
- [ ] Enrich.FromLogContext(): Enriquece o log com informações do contexto.
- [ ] .WriteTo.Console(): Escreve logs no console.
- [ ] .WriteTo.File("logs\\log.txt", rollingInterval: RollingInterval.Day): Escreve logs em um arquivo log.txt, com rotação diária.
- [ ] Integração com o Host da Aplicação: builder.Host.UseSerilog(): Configura o Serilog como o logger padrão para o host da aplicação.
- [ ] Configuração dos Serviços: builder.Services.AddControllers(): Adiciona serviços de controleadores à aplicação.